### PR TITLE
fix: Fix Scanf behaving differently on Windows and Unix

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -18,7 +18,7 @@ func ChooseCourse(courses Courses) int {
 	fmt.Println()
 	fmt.Println("Enter a number")
 	// TODO: Check input is within range and a number
-	fmt.Scanf("%d", &choice)
+	fmt.Scanf("%d\n", &choice)
 	log.Printf("User chose %d\n", choice)
 	log.Printf("Index is %d\n", choice-1)
 
@@ -43,7 +43,7 @@ func ChooseLectures(lectures Lectures) (int, int) {
 	// TODO: Add better range examples here
 	fmt.Println("Enter a range")
 	// TODO: Check input is within range and a number
-	fmt.Scanf("%d %d", &startIndex, &endIndex)
+	fmt.Scanf("%d %d\n", &startIndex, &endIndex)
 
 	log.Printf("User chose %d %d\n", startIndex, endIndex)
 	log.Printf("Indices are %d %d\n", startIndex-1, endIndex-1)


### PR DESCRIPTION
On Windows, the Scanf treats \r and \n as the same, causing the first Scanf to not consume the \r, thereby causing the succeeding Scanf to register the \n instead. Adding a \n to the end of the format specifier for Scanf is sufficient to avoid this.

Closes #5 